### PR TITLE
Decrease flickering & fix @super-fingers-extend

### DIFF
--- a/run.py
+++ b/run.py
@@ -12,7 +12,7 @@ from tmux_super_fingers import eval_file
 
 
 def main(stdscr: window) -> None:
-    if "FINGERS_EXTEND" in os.environ:
+    if "FINGERS_EXTEND" in os.environ and os.environ["FINGERS_EXTEND"] != "":
         eval_file(os.environ["FINGERS_EXTEND"])
 
     ui = CursesUI(stdscr)

--- a/run.py
+++ b/run.py
@@ -16,12 +16,12 @@ def main(stdscr: window) -> None:
         eval_file(os.environ["FINGERS_EXTEND"])
 
     ui = CursesUI(stdscr)
-    current_window = CurrentWindow(RealCliAdapter(), MarkFinder())
+    cli_adapter = RealCliAdapter()
+    current_window = CurrentWindow(cli_adapter, MarkFinder())
 
     renderer = PanesRenderer(ui, current_window.panes)
-    renderer.loop()
+    renderer.loop(cli_adapter)
 
-
-# Make escape delay unnoticable (it is very noticable by default)
+# Make escape delay unnoticeable (it is very noticeable by default)
 os.environ.setdefault('ESCDELAY', '25')
 wrapper(main)

--- a/run.sh
+++ b/run.sh
@@ -1,10 +1,12 @@
 #!/usr/bin/env bash
 
-CURRENT_DIR="$( cd "$( dirname "${BASH_SOURCE[0]}" )" && pwd )"
+CURRENT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
 
 rm -f /tmp/tmux_super_fingers_error.txt
 
-"$CURRENT_DIR/run.py" 2> /tmp/tmux_super_fingers_error.txt
+export FINGERS_TARGET_WINDOW=$(tmux display-message -p '#{window_id}')
+
+"$CURRENT_DIR/run.py" 2>/tmp/tmux_super_fingers_error.txt
 if [ $? -ne 0 ]; then
   cat /tmp/tmux_super_fingers_error.txt | less
 fi

--- a/tmux_super_fingers.tmux
+++ b/tmux_super_fingers.tmux
@@ -1,10 +1,10 @@
 #!/usr/bin/env bash
 
-CURRENT_DIR="$( cd "$( dirname "${BASH_SOURCE[0]}" )" && pwd )"
+CURRENT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
 
 DEFAULT_FINGERS_KEY="f"
 FINGERS_KEY=$(tmux show-option -gqv @super-fingers-key)
 FINGERS_KEY=${FINGERS_KEY:-$DEFAULT_FINGERS_KEY}
 FINGERS_EXTEND=$(tmux show-option -gqv @super-fingers-extend)
 
-tmux bind $FINGERS_KEY new-window -n super-fingers "$CURRENT_DIR/run.sh"
+tmux bind "$FINGERS_KEY" new-window -e "FINGERS_EXTEND=$FINGERS_EXTEND" -d -n super-fingers "$CURRENT_DIR/run.sh"

--- a/tmux_super_fingers/cli_adapter.py
+++ b/tmux_super_fingers/cli_adapter.py
@@ -51,6 +51,8 @@ class CliAdapter(metaclass=ABCMeta):  # pragma: no cover
 
 class RealCliAdapter(CliAdapter):  # pragma: no cover
     def current_tmux_window_panes_props(self) -> List[PaneProps]:
+        if "FINGERS_TARGET_WINDOW" in os.environ:
+            return self._get_panes_props(f'-t {os.environ["FINGERS_TARGET_WINDOW"]}')
         return self._get_panes_props('-t !')
 
     # TODO: there is too much logic here: extract into some testable code

--- a/tmux_super_fingers/panes_renderer.py
+++ b/tmux_super_fingers/panes_renderer.py
@@ -2,6 +2,7 @@ from typing import List, Optional, Generator
 from copy import deepcopy
 from curses import ascii
 
+from .cli_adapter import CliAdapter
 from .pane import Pane
 from .mark import Highlight, Mark
 from .ui import UI
@@ -20,8 +21,9 @@ class PanesRenderer:
         self.panes = panes
         self.secondary_mode = False
 
-    def loop(self) -> None:
+    def loop(self, cli_adapter: CliAdapter | None = None) -> None:
         user_input = ''
+        ready = False
 
         while True:
             panes = _discard_marks_that_dont_match_user_input(deepcopy(self.panes), user_input)
@@ -40,6 +42,10 @@ class PanesRenderer:
             for pane in panes:
                 self._render_pane_text(pane)
                 self._overlay_marks(pane, user_input)
+
+            if cli_adapter and not ready:
+                cli_adapter.select_tmux_window('super-fingers')
+                ready = True
 
             try:
                 user_input = self._handle_user_input(user_input)


### PR DESCRIPTION
## Problem

On my M1 Mac, super-fingers take a bit of time to load and render its UI. Before this PR, this feels pretty janky, since after pressing the hotkey, we immediately switch to a new empty window, then wait around a bit, before rendering.

In the below video, all I type is `<PREFIX> f`, then escape, to demonstrate the "jank" of the empty screen:

https://github.com/artemave/tmux_super_fingers/assets/296279/8919171f-473f-4030-a4bb-fe4432272f8d

## Solution

Now, we create the `super-fingers` window in the background and wait for the UI to finish rendering for the first time before focusing it. The user can still feel some lag in between pressing the hotkey and the window showing up, but there's no longer visual flickering.

## Bonus solution

For expediency I'm making a PR from my main branch, which also contains a fix for  https://github.com/artemave/tmux_super_fingers/issues/13

The issue was that the `FINGERS_EXTEND` environment variable wasn't propagated from the plugin setup script to the `run.sh` process.