### PR TITLE
Focus pane after open

### DIFF
--- a/README.md
+++ b/README.md
@@ -114,6 +114,18 @@ Now let's plug it in:
 set -g @super-fingers-extend /path/to/the/above/code.py
 ```
 
+## Troubleshooting
+
+Check `/tmp/tmux_super_fingers_error.txt` for errors:
+```
+tail -F /tmp/tmux_super_fingers_error.txt
+```
+
+### Text files are not opened in vim/nvim but in a different editor
+
+Please make sure your `EDITOR` env is set, and it's exclusively is set to `vim` or `nvim` (i.e. `EDITOR=/my/custom/path/nvim` will not work) 
+
+
 ## Development
 
 Prerequisites: python3, pipenv, node, make

--- a/tmux_super_fingers/actions/send_to_vim_in_tmux_pane_action.py
+++ b/tmux_super_fingers/actions/send_to_vim_in_tmux_pane_action.py
@@ -22,6 +22,7 @@ class SendToVimInTmuxPaneAction(Action):
                 editor_pane.pane_id,
                 f'Escape ":e {self._vim_e_args()}" Enter zz'
             )
+            self.cli_adapter.select_tmux_pane(editor_pane.pane_id)
         else:
             self.cli_adapter.new_tmux_window(
                 os.environ['EDITOR'],

--- a/tmux_super_fingers/actions/send_to_vim_in_tmux_pane_action_test.py
+++ b/tmux_super_fingers/actions/send_to_vim_in_tmux_pane_action_test.py
@@ -43,5 +43,6 @@ def test_sends_keys_to_existing_window_running_vim(monkeypatch: MonkeyPatch):
 
     assert cli_adapter.calls == [
         ['select_tmux_window', '2'],
-        ['tmux_send_keys', '2', 'Escape ":e +2 /tmp/file.txt" Enter zz']
+        ['tmux_send_keys', '2', 'Escape ":e +2 /tmp/file.txt" Enter zz'],
+        ['select_tmux_pane', '2']
     ]

--- a/tmux_super_fingers/cli_adapter.py
+++ b/tmux_super_fingers/cli_adapter.py
@@ -21,6 +21,10 @@ class CliAdapter(metaclass=ABCMeta):  # pragma: no cover
         ...
 
     @abstractmethod
+    def select_tmux_pane(self, id: str) -> None:
+        ...
+
+    @abstractmethod
     def tmux_send_keys(self, id: str, keys: str) -> None:
         ...
 
@@ -82,6 +86,9 @@ class RealCliAdapter(CliAdapter):  # pragma: no cover
 
     def select_tmux_window(self, id: str) -> None:
         os.system(f'tmux select-window -t {id}')
+
+    def select_tmux_pane(self, id: str) -> None:
+        os.system(f'tmux select-pane -t {id}')
 
     def tmux_send_keys(self, id: str, keys: str) -> None:
         os.system(f'tmux send-keys -t {id} {keys}')

--- a/tmux_super_fingers/test_utils.py
+++ b/tmux_super_fingers/test_utils.py
@@ -55,6 +55,9 @@ class MockCliAdapterBase(CliAdapter):  # pragma: no cover
     def select_tmux_window(self, id: str) -> None:
         self.calls.append(['select_tmux_window', id])
 
+    def select_tmux_pane(self, id: str) -> None:
+        self.calls.append(['select_tmux_pane', id])
+
     def new_tmux_window(self, name: str, command: str) -> None:
         self.calls.append(['new_tmux_window', name, command])
 


### PR DESCRIPTION
This PR adds a feature where the pane with Vim is focused after the file is opened. 

Admittedly, I'm not a Python developer, so this might be too hacky. I'm not even sure why `editor_pane.pane_id` works with `select_tmux_window` and with `select_tmux_pane`. This might be buggy under some edge cases (I have nvim in the first pane of the first window, and it works). 

Possibly - this feature should not be default but enabled with some config? 

ps. I love the plugin.