### PR TITLE
fix: file path finder to match paths with parenthesis

### DIFF
--- a/tmux_super_fingers/finders/file_path_finder.py
+++ b/tmux_super_fingers/finders/file_path_finder.py
@@ -12,7 +12,7 @@ class FilePathFinder(BaseFinder, FilePathFinderBase):
     @classmethod
     def pattern(cls) -> Pattern[str]:
         return re.compile(
-            r'([~./]?[-a-zA-Z0-9_+-,./@]+)(?:(?::|", line )(\d+))?'
+            r'([~./]?[-a-zA-Z0-9_+-,./@()\[\]]+)(?:(?::|", line )(\d+))?'
         )
 
     def match_to_mark(self, match: Match[str]) -> Optional[Mark]:

--- a/tmux_super_fingers/finders/file_path_finder_test.py
+++ b/tmux_super_fingers/finders/file_path_finder_test.py
@@ -140,3 +140,59 @@ def test_finds_directories(change_test_dir: str):
         )
     ]
     assert pane.marks == expected_marks
+
+
+def test_finds_file_with_parentheses_in_path(change_test_dir: str):
+    pane = {
+        'unwrapped_text': 'Path in ./app/(main)/controllers/index.tsx',
+        'current_path': os.getcwd()
+    }
+    expected_marks = [
+        Mark(
+            start=9,
+            text='./app/(main)/controllers/index.tsx',
+            target=FileTarget(
+                file_path=os.getcwd() + '/app/(main)/controllers/index.tsx',
+                content_type=ContentType.TEXT
+            )
+        )
+    ]
+    assert_marks(pane, expected_marks)
+
+
+def test_finds_file_with_square_brackets_in_path(change_test_dir: str):
+    pane = {
+        'unwrapped_text': 'Path in ./app/[id]/controllers/index.tsx',
+        'current_path': os.getcwd()
+    }
+    expected_marks = [
+        Mark(
+            start=9,
+            text='./app/[id]/controllers/index.tsx',
+            target=FileTarget(
+                file_path=os.getcwd() + '/app/[id]/controllers/index.tsx',
+                content_type=ContentType.TEXT
+            )
+        )
+    ]
+    assert_marks(pane, expected_marks)
+
+
+def test_with_parentheses_brackets_and_line_number(change_test_dir: str):
+    pane = {
+        'unwrapped_text': 'Error in ./app/(main)/[id]/index.tsx:45',
+        'current_path': os.getcwd()
+    }
+    expected_marks = [
+        Mark(
+            start=9,
+            text='./app/(main)/[id]/index.tsx:45',
+            target=FileTarget(
+                file_path=os.getcwd() + '/app/(main)/[id]/index.tsx',
+                content_type=ContentType.TEXT,
+                line_number=45
+            )
+        )
+    ]
+    assert_marks(pane, expected_marks)
+

--- a/tmux_super_fingers/finders/file_path_finder_test.py
+++ b/tmux_super_fingers/finders/file_path_finder_test.py
@@ -195,4 +195,3 @@ def test_with_parentheses_brackets_and_line_number(change_test_dir: str):
         )
     ]
     assert_marks(pane, expected_marks)
-

--- a/tmux_super_fingers/finders/file_path_finder_test.py
+++ b/tmux_super_fingers/finders/file_path_finder_test.py
@@ -143,55 +143,58 @@ def test_finds_directories(change_test_dir: str):
 
 
 def test_finds_file_with_parentheses_in_path(change_test_dir: str):
+    cwd = os.getcwd()
     pane = {
         'unwrapped_text': 'Path in ./app/(main)/controllers/index.tsx',
-        'current_path': os.getcwd()
+        'current_path': cwd
     }
     expected_marks = [
         Mark(
-            start=9,
+            start=8,
             text='./app/(main)/controllers/index.tsx',
             target=FileTarget(
-                file_path=os.getcwd() + '/app/(main)/controllers/index.tsx',
+                file_path=f'{cwd}/app/(main)/controllers/index.tsx',
                 content_type=ContentType.TEXT
             )
         )
     ]
-    assert_marks(pane, expected_marks)
+    assert_marks(pane, expected_marks, file_path=f'{cwd}/app/(main)/controllers/index.tsx')
 
 
 def test_finds_file_with_square_brackets_in_path(change_test_dir: str):
+    cwd = os.getcwd()
     pane = {
         'unwrapped_text': 'Path in ./app/[id]/controllers/index.tsx',
-        'current_path': os.getcwd()
+        'current_path': cwd
     }
     expected_marks = [
         Mark(
-            start=9,
+            start=8,
             text='./app/[id]/controllers/index.tsx',
             target=FileTarget(
-                file_path=os.getcwd() + '/app/[id]/controllers/index.tsx',
+                file_path=f'{cwd}/app/[id]/controllers/index.tsx',
                 content_type=ContentType.TEXT
             )
         )
     ]
-    assert_marks(pane, expected_marks)
+    assert_marks(pane, expected_marks, file_path=f'{cwd}/app/[id]/controllers/index.tsx')
 
 
 def test_with_parentheses_brackets_and_line_number(change_test_dir: str):
+    cwd = os.getcwd()
     pane = {
         'unwrapped_text': 'Error in ./app/(main)/[id]/index.tsx:45',
-        'current_path': os.getcwd()
+        'current_path': cwd
     }
     expected_marks = [
         Mark(
             start=9,
             text='./app/(main)/[id]/index.tsx:45',
             target=FileTarget(
-                file_path=os.getcwd() + '/app/(main)/[id]/index.tsx',
+                file_path=f'{cwd}/app/(main)/[id]/index.tsx',
                 content_type=ContentType.TEXT,
                 line_number=45
             )
         )
     ]
-    assert_marks(pane, expected_marks)
+    assert_marks(pane, expected_marks, file_path=f'{cwd}/app/(main)/[id]/index.tsx')


### PR DESCRIPTION
Resolves issue #16 

<img width="711" alt="image" src="https://github.com/user-attachments/assets/84f927a7-4de8-489e-b386-165c8bc67ec9">
