### PR TITLE
Fix wayland copying + multiple panes errors

### DIFF
--- a/tmux_super_fingers/cli_adapter.py
+++ b/tmux_super_fingers/cli_adapter.py
@@ -9,6 +9,7 @@ from .pane_props import PaneProps
 from .utils import shell, strip
 
 is_macos = 'darwin' in sys.platform.lower()
+is_wayland = 'XDG_SESSION_TYPE' in os.environ and os.environ['XDG_SESSION_TYPE'].lower() == 'wayland'
 
 
 class CliAdapter(metaclass=ABCMeta):  # pragma: no cover
@@ -115,7 +116,7 @@ class RealCliAdapter(CliAdapter):  # pragma: no cover
         )
 
     def copy_to_clipboard(self, text: str) -> None:
-        os_copy_to_clipboard = 'pbcopy' if is_macos else 'xclip'
+        os_copy_to_clipboard = 'pbcopy' if is_macos else 'wl-copy' if is_wayland else 'xclip'
         subprocess.run(os_copy_to_clipboard, shell=True, check=True, text=True, input=text)
 
     def get_file_type(self, path: str) -> str:

--- a/tmux_super_fingers/ui.py
+++ b/tmux_super_fingers/ui.py
@@ -59,11 +59,16 @@ class CursesUI(UI):  # pragma: no cover
     # Workaround for:
     # https://stackoverflow.com/questions/7063128/last-character-of-a-window-in-python-curses
     def render_line(self, y: int, x: int, line: str, color: int) -> None:
+        if len(line) == 0:
+            return
         try:
             self.window.addstr(y, x, line, color)
         except curses.error:
-            self.window.addstr(y, x, line[-1], color)
-            self.window.insstr(y, x, line[:-1], color)
+            try:
+                self.window.addstr(y, x, line[-1], color)
+                self.window.insstr(y, x, line[:-1], color)
+            except curses.error:
+                pass
 
         # Refreshing after each render does not seem to affect performance
         self.window.refresh()


### PR DESCRIPTION
Fixes two issues I ran into:
1. Copying didn't work under wayland compositors, now detects them and uses `wl-copy` which works with them.
2. I was getting errors when I opened multiple panes, scrolled back up in one of them then tried to use super_fingers. From the errors it seems that it tried to add an ncurses wstring in a too small area. Added enough failsafes so that it fails gracefully and still highlights other links.